### PR TITLE
Update bless.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "bless": "~3.0.0",
+    "bless": "git://github.com/michalkleiner/bless.js#cache-buster-hash",
     "chalk": "~0.5.1"
   },
   "devDependencies": {

--- a/tasks/bless.js
+++ b/tasks/bless.js
@@ -12,6 +12,7 @@ module.exports = function(grunt) {
 		bless = require('bless'),
 		util = require('util'),
 		chalk = require('chalk'),
+		crypto = require('crypto'),
 		OVERWRITE_ERROR = 'The destination is the same as the source for file ',
 		OVERWRITE_EXCEPTION = 'Cowardly refusing to overwrite the source file.';
 
@@ -19,6 +20,7 @@ module.exports = function(grunt) {
 
 		var options = this.options({
 			cacheBuster: true,
+			cacheBusterUseHash: false,
 			cleanup: true,
 			compress: false,
 			logCount: false,
@@ -55,7 +57,14 @@ module.exports = function(grunt) {
 			} else {
 				data += grunt.file.read(inputFile);
 			}
-
+			
+			if (options.cacheBuster && options.cacheBusterUseHash) {
+			    var hash = crypto.createHash('md5'); // md5 is still good enough to identify file's content
+			    hash.setEncoding('hex');
+			    hash.write(data);
+			    hash.end();
+				options.cacheBusterParam = hash.read();
+			}
 
 			new (bless.Parser)({
 				output: outPutfileName,


### PR DESCRIPTION
Allow to use content hash as a parameter instead of timestamp for cache buster query param.

Requires https://github.com/paulyoung/bless.js/pull/55 to be merged first prior using this feature. If the merge is not finished nothing happens as well as nothing breaks.
